### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Node.js Package
 
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Omid-Gharavi/Next-Exclude-Path/security/code-scanning/1](https://github.com/Omid-Gharavi/Next-Exclude-Path/security/code-scanning/1)

To address the flagged error, add a `permissions` block to restrict the privileges of the `GITHUB_TOKEN`. You can add this either at the workflow root—before the `jobs:` block—to affect all jobs, or inside the specific job (`publish-gpr`) if different jobs need different permissions (not required here since there is only one job). Since the minimal required permissions for publishing an npm package usually entail only read access to repository contents (`contents: read`) and, if pushing to GitHub Packages, potentially `packages: write` (not shown in this snippet as it publishes to npm), set the block to:

```yaml
permissions:
  contents: read
```

Add this block either above `jobs:` (to affect all jobs), or inside `publish-gpr` (to affect just this job). The best practice is to add it at the workflow root unless more jobs are added later that need other permissions.

No new imports or libraries are needed—this is a YAML config change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
